### PR TITLE
feat: fix issue with production build, remove inherited settings #149893

### DIFF
--- a/build.template.yaml
+++ b/build.template.yaml
@@ -24,7 +24,7 @@ jobs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
       verbose: false
-      customCommand: run ng build @audacia/${{parameters.project}} --configuration=production
+      customCommand: run build-prod @audacia/${{parameters.project}}
 
   - template: /src/build/npm/tasks/test.yaml@templates
     parameters:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build-prod": "ng build --configuration=production",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/projects/audacia/base-url-interceptor/tsconfig.lib.json
+++ b/projects/audacia/base-url-interceptor/tsconfig.lib.json
@@ -14,8 +14,6 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [

--- a/projects/audacia/date-parse-interceptor/tsconfig.lib.json
+++ b/projects/audacia/date-parse-interceptor/tsconfig.lib.json
@@ -14,8 +14,6 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [

--- a/projects/audacia/jwt-interceptor/tsconfig.lib.json
+++ b/projects/audacia/jwt-interceptor/tsconfig.lib.json
@@ -16,8 +16,6 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [

--- a/projects/audacia/request-disable-interceptor/tsconfig.lib.json
+++ b/projects/audacia/request-disable-interceptor/tsconfig.lib.json
@@ -14,8 +14,6 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [

--- a/projects/audacia/response-interceptor/tsconfig.lib.json
+++ b/projects/audacia/response-interceptor/tsconfig.lib.json
@@ -14,8 +14,6 @@
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [


### PR DESCRIPTION
Added an npm script to build in production configuration as the parameter was not being properly passed and build was being run in Ivy full compilation mode, which the publish rejects.

| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ✔ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |